### PR TITLE
updated Google Analytics tracking number to enable cross-domain tracking

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://team-admin.rstudio.com/"
 
 ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 
@@ -35,7 +35,7 @@ unsafe = true
     github_doc_repository = "https://github.com/thingsym/hugo-theme-techdoc"
 
     # Analytic section
-    google_analytics_id = "UA-20375833-26" # Your Google Analytics tracking id
+    google_analytics_id = "UA-20375833-3" # Your Google Analytics tracking id
     tag_manager_container_id = "" # Your Google Tag Manager container id
     google_site_verification = "" # Your Google Site Verification for Search Console
 


### PR DESCRIPTION
@andrie 
I’ve replaced your Google Analytics tracking number with the one for rstudio.com, which enables us to track users across domains.  Your site’s analytics will now be found under the rstudio.com property and I have built a segment for you to view your site’s metrics separate from other domains.  Data will populate from today forward and you will need to visit your previous property for historical data.  Thank you for merging this pull request so that we can get a full picture of online user behavior.